### PR TITLE
improvements for build and more distros

### DIFF
--- a/DistroInfo.cs
+++ b/DistroInfo.cs
@@ -48,9 +48,17 @@ public class DistroInfo
     {
       Name = "Ubuntu2204",
       Family = "Ubuntu",
-      ImageName = "focal-server-cloudimg-amd64.img",
+      ImageName = "jammy-server-cloudimg-amd64.img",
       Url = "https://cloud-images.ubuntu.com/jammy/current/",
       Aliases = new[] { "Jammy Jellyfish", "Jammy" }
+    },
+    new()
+    {
+      Name = "Ubuntu2304",
+      Family = "Ubuntu",
+      ImageName = "lunar-server-cloudimg-amd64.img",
+      Url = "https://cloud-images.ubuntu.com/lunar/current/",
+      Aliases = new[] { "Lunar Lobster", "Lunar" }
     },
     new()
     {
@@ -65,7 +73,7 @@ public class DistroInfo
       Name = "Fedora36",
       Family = "Fedora",
       ImageName = "Fedora-Cloud-Base-36-1.5.x86_64.qcow2",
-      Url = "https://download.fedoraproject.org/pub/fedora/linux/releases/37/Cloud/x86_64/images/",
+      Url = "https://download.fedoraproject.org/pub/fedora/linux/releases/36/Cloud/x86_64/images/",
       Aliases = Array.Empty<string>()
     },
     new()
@@ -82,6 +90,22 @@ public class DistroInfo
       Family = "RHEL",
       ImageName = "CentOS-7-x86_64-GenericCloud.qcow2",
       Url = "https://cloud.centos.org/centos/7/images/",
+      Aliases = Array.Empty<string>()
+    },
+    new()
+    {
+      Name = "Rocky8",
+      Family = "RHEL",
+      ImageName = "Rocky-8-GenericCloud.latest.x86_64.qcow2",
+      Url = "https://download.rockylinux.org/pub/rocky/8/images/x86_64/",
+      Aliases = Array.Empty<string>()
+    },
+    new()
+    {
+      Name = "Rocky9",
+      Family = "RHEL",
+      ImageName = "Rocky-9-GenericCloud.latest.x86_64.qcow2",
+      Url = "https://download.rockylinux.org/pub/rocky/9/images/x86_64/",
       Aliases = Array.Empty<string>()
     },
     new()

--- a/DistroInfo.cs
+++ b/DistroInfo.cs
@@ -10,7 +10,9 @@ public class DistroInfo
       Family = "Debian",
       ImageName = "debian-11-genericcloud-amd64.qcow2",
       Url = "https://cloud.debian.org/images/cloud/bullseye/latest/",
-      Aliases = new[] { "Bullseye" }
+      Aliases = new[] { "Bullseye" },
+      ChecksumFile = "SHA512SUMS",
+      ChecksumType = "sha512"
     },
     new()
     {
@@ -18,7 +20,9 @@ public class DistroInfo
       Family = "Debian",
       ImageName = "debian-10-genericcloud-amd64.qcow2",
       Url = "https://cloud.debian.org/images/cloud/buster/latest/",
-      Aliases = new[] { "Buster" }
+      Aliases = new[] { "Buster" },
+      ChecksumFile = "SHA512SUMS",
+      ChecksumType = "sha512"
     },
     new()
     {
@@ -26,7 +30,9 @@ public class DistroInfo
       Family = "Ubuntu",
       ImageName = "bionic-server-cloudimg-amd64.img",
       Url = "https://cloud-images.ubuntu.com/bionic/current/",
-      Aliases = new[] { "Bionic Beaver", "Bionic" }
+      Aliases = new[] { "Bionic Beaver", "Bionic" },
+      ChecksumFile = "SHA256SUMS",
+      ChecksumType = "sha256"
     },
     new()
     {
@@ -34,7 +40,9 @@ public class DistroInfo
       Family = "Ubuntu",
       ImageName = "focal-server-cloudimg-amd64.img",
       Url = "https://cloud-images.ubuntu.com/focal/current/",
-      Aliases = new[] { "Focal Fossal", "Focal" }
+      Aliases = new[] { "Focal Fossal", "Focal" },
+      ChecksumFile = "SHA256SUMS",
+      ChecksumType = "sha256"
     },
     new()
     {
@@ -42,7 +50,9 @@ public class DistroInfo
       Family = "Ubuntu",
       ImageName = "jammy-server-cloudimg-amd64.img",
       Url = "https://cloud-images.ubuntu.com/jammy/current/",
-      Aliases = new[] { "Jammy Jellyfish", "Jammy" }
+      Aliases = new[] { "Jammy Jellyfish", "Jammy" },
+      ChecksumFile = "SHA256SUMS",
+      ChecksumType = "sha256"
     },
     new()
     {
@@ -50,7 +60,9 @@ public class DistroInfo
       Family = "Ubuntu",
       ImageName = "lunar-server-cloudimg-amd64.img",
       Url = "https://cloud-images.ubuntu.com/lunar/current/",
-      Aliases = new[] { "Lunar Lobster", "Lunar" }
+      Aliases = new[] { "Lunar Lobster", "Lunar" },
+      ChecksumFile = "SHA256SUMS",
+      ChecksumType = "sha256"
     },
     new()
     {
@@ -58,7 +70,9 @@ public class DistroInfo
       Family = "Arch",
       ImageName = "Arch-Linux-x86_64-cloudimg.qcow2",
       Url = "https://geo.mirror.pkgbuild.com/images/latest/",
-      Aliases = Array.Empty<string>()
+      Aliases = Array.Empty<string>(),
+      ChecksumFile = "Arch-Linux-x86_64-cloudimg.qcow2.SHA256",
+      ChecksumType = "sha256"
     },
     new()
     {
@@ -66,7 +80,9 @@ public class DistroInfo
       Family = "Fedora",
       ImageName = "Fedora-Cloud-Base-36-1.5.x86_64.qcow2",
       Url = "https://download.fedoraproject.org/pub/fedora/linux/releases/36/Cloud/x86_64/images/",
-      Aliases = Array.Empty<string>()
+      Aliases = Array.Empty<string>(),
+      ChecksumFile = "Fedora-Cloud-36-1.5-x86_64-CHECKSUM",
+      ChecksumType = "sha256"
     },
     new()
     {
@@ -74,7 +90,9 @@ public class DistroInfo
       Family = "Fedora",
       ImageName = "Fedora-Cloud-Base-37-1.7.x86_64.qcow2",
       Url = "https://download.fedoraproject.org/pub/fedora/linux/releases/37/Cloud/x86_64/images/",
-      Aliases = Array.Empty<string>()
+      Aliases = Array.Empty<string>(),
+      ChecksumFile = "Fedora-Cloud-37-1.7-x86_64-CHECKSUM",
+      ChecksumType = "sha256"
     },
     new()
     {
@@ -82,7 +100,9 @@ public class DistroInfo
       Family = "RHEL",
       ImageName = "CentOS-7-x86_64-GenericCloud.qcow2",
       Url = "https://cloud.centos.org/centos/7/images/",
-      Aliases = Array.Empty<string>()
+      Aliases = Array.Empty<string>(),
+      ChecksumFile = "sha256sum.txt",
+      ChecksumType = "sha256"
     },
     new()
     {
@@ -90,7 +110,9 @@ public class DistroInfo
       Family = "RHEL",
       ImageName = "Rocky-8-GenericCloud.latest.x86_64.qcow2",
       Url = "https://download.rockylinux.org/pub/rocky/8/images/x86_64/",
-      Aliases = Array.Empty<string>()
+      Aliases = Array.Empty<string>(),
+      ChecksumFile = "CHECKSUM",
+      ChecksumType = "sha256"
     },
     new()
     {
@@ -98,7 +120,9 @@ public class DistroInfo
       Family = "RHEL",
       ImageName = "Rocky-9-GenericCloud.latest.x86_64.qcow2",
       Url = "https://download.rockylinux.org/pub/rocky/9/images/x86_64/",
-      Aliases = Array.Empty<string>()
+      Aliases = Array.Empty<string>(),
+      ChecksumFile = "CHECKSUM",
+      ChecksumType = "sha256"
     },
     new()
     {
@@ -106,7 +130,9 @@ public class DistroInfo
       Family = "RHEL",
       ImageName = "AlmaLinux-8-GenericCloud-latest.x86_64.qcow2",
       Url = "https://repo.almalinux.org/almalinux/8/cloud/x86_64/images/",
-      Aliases = Array.Empty<string>()
+      Aliases = Array.Empty<string>(),
+      ChecksumFile = "CHECKSUM",
+      ChecksumType = "sha256"
     },
     new()
     {
@@ -114,7 +140,9 @@ public class DistroInfo
       Family = "RHEL",
       ImageName = "AlmaLinux-9-GenericCloud-latest.x86_64.qcow2",
       Url = "https://repo.almalinux.org/almalinux/9/cloud/x86_64/images/",
-      Aliases = Array.Empty<string>()
+      Aliases = Array.Empty<string>(),
+      ChecksumFile = "CHECKSUM",
+      ChecksumType = "sha256"
     }
   };
 
@@ -130,10 +158,12 @@ public class DistroInfo
     return new DistroInfo()
     {
       Name = "local",
-      Aliases = Array.Empty<string>(),
       Family = "local",
+      ImageName = localImage.Name,
       Url = "file://" + localImageDirectory?.FullName,
-      ImageName = localImage.Name
+      Aliases = Array.Empty<string>(),
+      ChecksumFile = "",
+      ChecksumType = ""
     };
   }
 
@@ -142,4 +172,6 @@ public class DistroInfo
   public required string ImageName { get; set; }
   public required string Url { get; set; }
   public required string[] Aliases { get; set; }
+  public required string ChecksumFile { get; set; }
+  public required string ChecksumType { get; set; }
 }

--- a/DistroInfo.cs
+++ b/DistroInfo.cs
@@ -22,14 +22,6 @@ public class DistroInfo
     },
     new()
     {
-      Name = "Debian9",
-      Family = "Debian",
-      ImageName = "debian-9-genericcloud-amd64.qcow2",
-      Url = "https://cloud.debian.org/images/cloud/stretch/latest/",
-      Aliases = new[] { "Stretch" }
-    },
-    new()
-    {
       Name = "Ubuntu1804",
       Family = "Ubuntu",
       ImageName = "bionic-server-cloudimg-amd64.img",

--- a/Downloader.cs
+++ b/Downloader.cs
@@ -14,7 +14,7 @@ public class Downloader
 
   public async Task<FileInfo> DownloadAsync(DistroInfo distroInfo, bool force = false)
   {
-    var targetFile = new FileInfo(Path.Combine(_cacheDirectory.FullName, distroInfo.ImageName + ".qcow2"));
+    var targetFile = new FileInfo(Path.Combine(_cacheDirectory.FullName, distroInfo.ImageName));
 
     if (targetFile.Exists && !force)
     {
@@ -22,7 +22,7 @@ public class Downloader
       return targetFile;
     }
 
-    var uri = new Uri($"{distroInfo.Url}/{distroInfo.ImageName}");
+    var uri = new Uri(new Uri(distroInfo.Url), distroInfo.ImageName);
 
     AnsiConsole.WriteLine($"Download: {uri}");
 

--- a/README.md
+++ b/README.md
@@ -61,3 +61,19 @@ Commands:
   list, ls, ps                   list all existing vms
   images, os                     get a list of all available os images
 ```
+
+## 🏗️ Build
+
+Simply use the included bash script as follows:
+
+```bash
+./build <version> <output dir>
+```
+
+For example:
+
+```bash
+./build 1.2.3 ~/build/
+```
+
+Output dir defaults to `./build/`.

--- a/build.sh
+++ b/build.sh
@@ -26,8 +26,8 @@ OUTPUT_DIR_REALPATH=$(realpath "$OUTPUT_DIR")
 # build image
 echo -e "${BOLD_BLUE}ℹ️ Build version: ${TARGET_VERSION}${NC}"
 echo -e "${BOLD_BLUE}ℹ️ Output dir: ${OUTPUT_DIR_REALPATH}/${NC}"
-
 echo ""
+
 echo -ne "${BLUE}🏗️ Docker build image...${NC}"
 docker build --build-arg TARGET_VERSION="$TARGET_VERSION" -t vmchamp:latest -q . > /dev/null
 echo -e "${GREEN} done${NC}"
@@ -37,7 +37,7 @@ docker create --name vmchamp -q vmchamp:latest exit 0 > /dev/null
 echo -e "${GREEN} done${NC}"
 
 echo -ne "${BLUE}🏗️ Docker copy binary...${NC}"
-docker cp -q vmchamp:/VmChamp "$OUTPUT_DIR/VmChamp" > /dev/null
+docker cp -q vmchamp:/App/build/VmChamp "$OUTPUT_DIR/VmChamp" > /dev/null
 echo -e "${GREEN} done${NC}"
 
 echo -ne "${BLUE}🏗️ Docker remove container...${NC}"

--- a/build.sh
+++ b/build.sh
@@ -37,7 +37,7 @@ docker create --name vmchamp -q vmchamp:latest exit 0 > /dev/null
 echo -e "${GREEN} done${NC}"
 
 echo -ne "${BLUE}🏗️ Docker copy binary...${NC}"
-docker cp -q vmchamp:/App/build/VmChamp "$OUTPUT_DIR/VmChamp" > /dev/null
+docker cp -q vmchamp:/VmChamp "$OUTPUT_DIR/VmChamp" > /dev/null
 echo -e "${GREEN} done${NC}"
 
 echo -ne "${BLUE}🏗️ Docker remove container...${NC}"

--- a/build.sh
+++ b/build.sh
@@ -1,11 +1,48 @@
 #!/bin/bash
 
+# exit on fail
+set -e
+
+# set colors
+RED="\033[0;31m"
+GREEN="\033[0;32m"
+BLUE="\033[0;34m"
+BOLD_BLUE='\033[1;34m'
+NC='\033[0m'
+
+# check shell args
 TARGET_VERSION="${1:-1.0.0}"
-OUTPUT_DIR="${2:-'/tmp'}"
+if [[ ! "$TARGET_VERSION" =~ ^([0-9].){2}[0-9] ]]; then
+    echo -e "${RED}❌ ${TARGET_VERSION} is not a valid version. Please use semantic versioning (e.g. \"1.2.3\")${NC}"
+    exit 1
+fi
+OUTPUT_DIR="${2:-build}"
+if [ ! -d "$OUTPUT_DIR" ]; then
+    mkdir -p "$OUTPUT_DIR"
+fi
 
-echo "BUILD VERSION $TARGET_VERSION"
+OUTPUT_DIR_REALPATH=$(realpath "$OUTPUT_DIR")
 
-ID=$(docker build --build-arg TARGET_VERSION="$TARGET_VERSION" . -q | cut -d ":" -f 2)
-docker run --name tmpbuild "$ID"
-docker cp tmpbuild:/App/build/VmChamp "$OUTPUT_DIR"
-docker rm tmpbuild
+# build image
+echo -e "${BOLD_BLUE}ℹ️ Build version: ${TARGET_VERSION}${NC}"
+echo -e "${BOLD_BLUE}ℹ️ Output dir: ${OUTPUT_DIR_REALPATH}/${NC}"
+
+echo ""
+echo -ne "${BLUE}🏗️ Docker build image...${NC}"
+docker build --build-arg TARGET_VERSION="$TARGET_VERSION" -t vmchamp:latest -q . > /dev/null
+echo -e "${GREEN} done${NC}"
+
+echo -ne "${BLUE}🏗️ Docker create container...${NC}"
+docker create --name vmchamp -q vmchamp:latest exit 0 > /dev/null
+echo -e "${GREEN} done${NC}"
+
+echo -ne "${BLUE}🏗️ Docker copy binary...${NC}"
+docker cp -q vmchamp:/VmChamp "$OUTPUT_DIR/VmChamp" > /dev/null
+echo -e "${GREEN} done${NC}"
+
+echo -ne "${BLUE}🏗️ Docker remove container...${NC}"
+docker rm -f vmchamp > /dev/null
+echo -e "${GREEN} done${NC}"
+
+echo ""
+echo -e "${GREEN}✅ Build successful${NC} - Binary available at $OUTPUT_DIR_REALPATH/VmChamp"


### PR DESCRIPTION
- better build output for .sh file
- fix link ubuntu 22.04
- fix link fedora 36
- add rocky 8 and 9
- add ubuntu 23.04 (still beta)
- dont add additional .qcow2 to downloaded images
- avoid multiple url slashes in download