### PR TITLE
Added new feature to check the image checksum after download

### DIFF
--- a/ChecksumHelper.cs
+++ b/ChecksumHelper.cs
@@ -1,0 +1,106 @@
+using System.Security.Cryptography;
+using Spectre.Console;
+
+namespace VmChamp;
+
+public class ChecksumHelper
+{
+    private string ConvertHashToString(byte[] hash)
+    {
+        return BitConverter.ToString(hash).Replace("-", "");
+    }
+
+    public bool CompareHash(byte[] firstHash, byte[] secondHash)
+    {
+        if (ConvertHashToString(firstHash) == ConvertHashToString(secondHash)) return true;
+        else return false;
+    }
+    
+    public string GetSHA1(string inputFile)
+    {
+        using (var sha1 = SHA1.Create())
+        using (var stream = File.OpenRead(inputFile))
+            return ConvertHashToString(sha1.ComputeHash(stream));
+    }
+
+    public string GetSHA256(string inputFile)
+    {
+        using (var sha256 = SHA256.Create())
+        using (var stream = File.OpenRead(inputFile))
+            return ConvertHashToString(sha256.ComputeHash(stream));
+    }
+
+    public string GetSHA512(string inputFile)
+    {
+        using (var sha512 = SHA512.Create())
+        using (var stream = File.OpenRead(inputFile))
+            return ConvertHashToString(sha512.ComputeHash(stream));
+            
+            
+    }
+    
+    public bool ReadChecksum(string checksumInputFile, string hash)
+    {
+        ;
+        if (!File.Exists(checksumInputFile))
+        {
+            return false;
+        }
+        foreach (string line in File.ReadLines(checksumInputFile))
+        {
+            string[] compare;
+            compare = line.Split(" ");
+            
+            
+            for(int i = 0; i < compare.Length; i++)
+            {
+                if ((compare[i].ToLower()) == (hash.ToLower()))
+                {
+                    return true;
+                }
+            }
+            
+
+        }
+
+        return false;
+    }
+
+    public int ChecksumCheck(DistroInfo distroInfo, FileInfo targetFile, FileInfo checksumFile)
+    {
+       switch (distroInfo.ChecksumType)
+        {
+            case "sha1":
+                if (ReadChecksum(checksumFile.ToString(), GetSHA1(targetFile.FullName)))
+                {
+                    return 1;
+                }
+
+                break;
+
+
+            case "sha256":
+                if (ReadChecksum(checksumFile.ToString(), GetSHA256(targetFile.FullName)))
+                {
+                    return 1;
+                }
+                break;
+
+            case "sha512":
+                if (ReadChecksum(checksumFile.ToString(), GetSHA512(targetFile.FullName)))
+                {
+                    return 1;
+                }
+
+                break;
+
+
+            default:
+                return 2;
+        }
+
+        return 0;
+
+    }
+
+}

--- a/ChecksumHelper.cs
+++ b/ChecksumHelper.cs
@@ -10,27 +10,27 @@ public class ChecksumHelper
         return BitConverter.ToString(hash).Replace("-", "");
     }
 
-    public bool CompareHash(byte[] firstHash, byte[] secondHash)
+    private bool CompareHash(byte[] firstHash, byte[] secondHash)
     {
         if (ConvertHashToString(firstHash) == ConvertHashToString(secondHash)) return true;
         else return false;
     }
     
-    public string GetSHA1(string inputFile)
+    private string GetSHA1(string inputFile)
     {
         using (var sha1 = SHA1.Create())
         using (var stream = File.OpenRead(inputFile))
             return ConvertHashToString(sha1.ComputeHash(stream));
     }
 
-    public string GetSHA256(string inputFile)
+    private string GetSHA256(string inputFile)
     {
         using (var sha256 = SHA256.Create())
         using (var stream = File.OpenRead(inputFile))
             return ConvertHashToString(sha256.ComputeHash(stream));
     }
 
-    public string GetSHA512(string inputFile)
+    private string GetSHA512(string inputFile)
     {
         using (var sha512 = SHA512.Create())
         using (var stream = File.OpenRead(inputFile))
@@ -39,7 +39,7 @@ public class ChecksumHelper
             
     }
     
-    public bool ReadChecksum(string checksumInputFile, string hash)
+    private bool ReadChecksum(string checksumInputFile, string hash)
     {
         ;
         if (!File.Exists(checksumInputFile))

--- a/DistroInfo.cs
+++ b/DistroInfo.cs
@@ -172,8 +172,8 @@ public class DistroInfo
       ImageName = localImage.Name,
       Url = "file://" + localImageDirectory?.FullName,
       Aliases = Array.Empty<string>(),
-      ChecksumFile = "",
-      ChecksumType = ""
+      ChecksumFile = "/dev/null",
+      ChecksumType = "none"
     };
   }
 

--- a/DistroInfo.cs
+++ b/DistroInfo.cs
@@ -111,8 +111,8 @@ public class DistroInfo
       ImageName = "CentOS-7-x86_64-GenericCloud.qcow2",
       Url = "https://cloud.centos.org/centos/7/images/",
       Aliases = Array.Empty<string>(),
-      ChecksumFile = "sha256sum.txt",
-      ChecksumType = "sha256"
+      ChecksumFile = "/dev/null",
+      ChecksumType = "none"
     },
     new()
     {

--- a/Downloader.cs
+++ b/Downloader.cs
@@ -1,3 +1,4 @@
+
 namespace VmChamp;
 
 using System.Net;
@@ -6,10 +7,13 @@ using Spectre.Console;
 public class Downloader
 {
   private readonly DirectoryInfo _cacheDirectory;
+  private readonly ChecksumHelper _checksumHelper;
 
   public Downloader(DirectoryInfo cacheDirectory)
   {
     _cacheDirectory = cacheDirectory;
+    _checksumHelper = new ChecksumHelper();
+
   }
 
   public async Task<FileInfo> DownloadAsync(DistroInfo distroInfo, bool force = false)
@@ -23,12 +27,34 @@ public class Downloader
     }
 
     var uri = new Uri(new Uri(distroInfo.Url), distroInfo.ImageName);
+    var checksumFileUri = new Uri(new Uri(distroInfo.Url), distroInfo.ChecksumFile);
+    var checksumFile = new FileInfo(Path.Combine(_cacheDirectory.FullName, distroInfo.ImageName + "." + distroInfo.ChecksumType));
 
-    AnsiConsole.WriteLine($"Download: {uri}");
-
+    
+    
 #pragma warning disable SYSLIB0014
     var webClient = new WebClient();
 #pragma warning restore SYSLIB0014
+
+    //Download checksum file
+    if (distroInfo.ChecksumFile != "/dev/null") //Set /dev/null as checksum file if distro has no (working) checksum file
+    {
+      AnsiConsole.WriteLine($"Download: {checksumFileUri}");
+
+      await AnsiConsole.Progress()
+        .Columns(new SpinnerColumn(), new PercentageColumn(), new RemainingTimeColumn())
+        .StartAsync(async ctx =>
+        {
+          var task = ctx.AddTask($"progress");
+
+          webClient.DownloadProgressChanged += (_, eventArgs) => { task.Value = eventArgs.ProgressPercentage; };
+
+          await webClient.DownloadFileTaskAsync(checksumFileUri, checksumFile.FullName);
+        });
+    }
+
+    //Download Image File
+    AnsiConsole.WriteLine($"Download: {uri}");
 
     await AnsiConsole.Progress()
       .Columns(new SpinnerColumn(), new PercentageColumn(), new RemainingTimeColumn())
@@ -40,6 +66,27 @@ public class Downloader
 
         await webClient.DownloadFileTaskAsync(uri, targetFile.FullName);
       });
+
+    int checksumcheck = _checksumHelper.ChecksumCheck(distroInfo, targetFile, checksumFile); //Doing checksum checking and calculating
+
+    switch (checksumcheck)
+    {
+      case 1:
+      AnsiConsole.WriteLine("The checksum is good!");
+        break;
+
+      case 0:
+        AnsiConsole.WriteLine("The checksum is wrong, exiting!");
+        Environment.Exit(0);
+        break;
+
+      case 2:
+        AnsiConsole.WriteLine("Warning: The checksum not verified!");
+        break;
+
+
+    }
+
 
     return targetFile;
   }


### PR DESCRIPTION
Added new feature to check the image checksum after download.

- If the checksum is good, the user is informed with "The checksum is good" before first VM start with the image.

- If the checksum is bad, the user is informed with "The checksum is wrong, exiting!" and the does not start the VM first try after downloading.

- If the checksum is not checked (not existing), the user is warned with "Warning: The checksum not verified!". (The ChecksumFile must point to /dev/null)