### PR TITLE
Fix & Update DOCKERFILE

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,9 +14,9 @@ COPY *.csproj ./
 ARG TARGET_VERSION
 RUN ~/.dotnet/dotnet publish -r linux-x64 --configuration Release -p:Version=$TARGET_VERSION --self-contained=true -p:PublishAot=true -p:StripSymbols=true -o build
 
-FROM scratch as output
+FROM scratch AS output
 COPY --from=build /App/build/VmChamp /VmChamp
 
-FROM build as release
+FROM build AS release
 COPY --from=build /App/build/VmChamp /VmChamp
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,14 +2,13 @@ FROM ubuntu:20.04 AS build
 WORKDIR /App
 
 # Install dependencies
-RUN apt-get update && apt-get install -y curl zlib1g-dev build-essential
+RUN apt-get update && apt-get install -y curl zlib1g-dev build-essential libicu-dev
 
 # Install .NET
 RUN curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin -c 8.0
 
 COPY *.cs ./
 COPY *.csproj ./
-ARG DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1
 ARG TARGET_VERSION
 RUN ~/.dotnet/dotnet publish -r linux-x64 --configuration Release -p:Version=$TARGET_VERSION --self-contained=true -p:PublishAot=true -p:StripSymbols=true -o build
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,12 @@
-FROM centos:7 AS build
+FROM ubuntu:20.04 AS build
 WORKDIR /App
 
-RUN ulimit -n 1024 && yum -y update 
-RUN ulimit -n 1024 && yum -y install curl zlib-devel build-essential
-RUN ulimit -n 1024 && yum -y groupinstall 'Development Tools'
+# Install dependencies
+RUN apt-get update && apt-get install -y curl zlib1g-dev build-essential
+
+# Install .NET
 RUN curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin -c 8.0
+
 COPY *.cs ./
 COPY *.csproj ./
 ARG DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,12 @@
 FROM ubuntu:20.04 AS build
 WORKDIR /App
 
-# Install dependencies
-RUN apt-get update && apt-get install -y curl zlib1g-dev build-essential libicu-dev
+# Set variables to configure timezone non-interactively
+ENV DEBIAN_FRONTEND=noninteractive
+ENV TZ=Etc/UTC
 
-# Install .NET
+RUN apt-get update && apt-get install -y curl zlib1g-dev build-essential libicu-dev tzdata
+
 RUN curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin -c 8.0
 
 COPY *.cs ./


### PR DESCRIPTION
Old build process ran into:
/lib64/libstdc++.so.6: version `GLIBCXX_3.4.21' not found

- Updated Buildprocess in Dockerifle to Ubuntu 20.04
- Fix FromAsCase Warnings
- Fix globalization-invariant mode error when building